### PR TITLE
feat: Enable direct connection to the host system using localhost by ...

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,7 @@ services:
   marzneshin_ip_limit:
     image: ghcr.io/muttehitler/marzneshiniplimit:main
     restart: always
-    ports:
-      - 6284:6284
+    network_mode: host
     volumes:
       - /opt/marzneshiniplimit/config.json:/marzneshiniplimitcode/config.json
       - /opt/marzneshiniplimit/app.log:/marzneshiniplimitcode/app.log


### PR DESCRIPTION
…switching to host network mode

- Changed network_mode to 'host' for the marzneshin_ip_limit service
- Removed the port mapping as it's no longer needed with host network mode
- Now localhost can be used for accessing the service directly from within the container